### PR TITLE
Add time parser and UI enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Aplicación de escritorio en Python para descargar un fragmento de un video de Y
 ## ¿Qué hace la aplicación?
 
 1. Permite ingresar la URL de un video de YouTube.
-2. Se elige un tiempo de inicio y de fin (en formato `mm:ss` o `hh:mm:ss`).
+2. Se elige un tiempo de inicio y de fin (en formato `m:ss` o `h:m:ss`).
 3. Al presionar el botón, descarga solo ese fragmento utilizando `yt-dlp`.
 4. Convierte el audio a `mp3` mediante `ffmpeg`.
 5. Guarda el resultado en `C:\YoutubeCuts` (se crea automáticamente si no existe).
@@ -25,7 +25,7 @@ python app.py
 ```
 
 1. Ingresa la URL de YouTube.
-2. Especifica el tiempo de inicio y fin del fragmento.
+2. Especifica el tiempo de inicio y fin del fragmento (por ejemplo `9:34` o `1:02:30`).
 3. Presiona **Download clip** y espera el mensaje de éxito.
 
 El archivo MP3 se guardará dentro de `C:\YoutubeCuts`.


### PR DESCRIPTION
## Summary
- allow entering time without leading zeros via `normalize_time`
- open download directory automatically
- use YouTube colors in the GUI
- update README examples

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68857a3d8ddc8328bc7e7d136c2dba5a